### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Go 语言版本的 OpenClaw - 一个功能强大的 AI Agent 框架。
 - 💾 **持久化会话**：基于 JSONL 的会话存储，支持完整的工具调用链 (Tool Calls) 记录与恢复
 - 📢 **多渠道支持**：Telegram、WhatsApp、飞书 (Feishu)、QQ、企业微信 (WeWork)、钉钉 (DingTalk)、百度如流 (Infoflow)、Gotify、Slack、Discord、Google Chat、Microsoft Teams、微信 (Weixin)
 - 🔧 **灵活配置**：支持 YAML/JSON 配置，热加载，环境变量支持
-- 🎯 **多 LLM 提供商**：OpenAI、Qianfan（百度千帆，OpenAI-compatible）、Anthropic、OpenRouter，支持故障转移
+- 🎯 **多 LLM 提供商**：OpenAI、Qianfan（百度千帆，OpenAI-compatible）、Anthropic、OpenRouter、Requesty，支持故障转移
 - 🌐 **WebSocket Gateway**：内置网关服务，支持实时通信
 - ⏰ **Cron 调度**：内置定时任务调度器
 - 🖥️ **Browser 自动化**：基于 Chrome DevTools Protocol 的浏览器控制
@@ -123,7 +123,8 @@ goclaw/
 │   ├── factory.go      # 提供商工厂
 │   ├── openai.go       # OpenAI 实现
 │   ├── anthropic.go    # Anthropic 实现
-│   └── openrouter.go   # OpenRouter 实现
+│   ├── openrouter.go   # OpenRouter 实现
+│   └── requesty.go     # Requesty 实现
 ├── gateway/            # WebSocket 网关
 │   ├── server.go       # 网关服务器
 │   ├── handler.go      # 消息处理器
@@ -612,6 +613,7 @@ A: 在 `models.providers` 中配置提供商，然后在 `agents.defaults.model.
 - `openai/gpt-4o` - OpenAI
 - `anthropic/claude-sonnet-4-20250514` - Anthropic
 - `openrouter/anthropic/claude-sonnet-4` - OpenRouter
+- `requesty/anthropic/claude-sonnet-4-5` - Requesty
 
 ### Q: 工具调用失败怎么办？
 

--- a/cli/onboard.go
+++ b/cli/onboard.go
@@ -38,7 +38,7 @@ func init() {
 	onboardCmd.Flags().StringVarP(&onboardAPIKey, "api-key", "k", "", "API key for the provider (required in non-interactive mode)")
 	onboardCmd.Flags().StringVarP(&onboardBaseURL, "base-url", "u", "", "Base URL for the provider API")
 	onboardCmd.Flags().StringVarP(&onboardModel, "model", "m", "", "Model name to use")
-	onboardCmd.Flags().StringVarP(&onboardProvider, "provider", "p", "qianfan", "Provider name (e.g., qianfan, openai, anthropic, openrouter)")
+	onboardCmd.Flags().StringVarP(&onboardProvider, "provider", "p", "qianfan", "Provider name (e.g., qianfan, openai, anthropic, openrouter, requesty)")
 	onboardCmd.Flags().BoolVar(&onboardSkipPrompts, "skip-prompts", false, "Skip all prompts (use defaults)")
 }
 
@@ -179,6 +179,7 @@ func interactiveSetup(cfg *config.Config) error {
 		fmt.Println("    - openai")
 		fmt.Println("    - anthropic")
 		fmt.Println("    - openrouter")
+		fmt.Println("    - requesty")
 		fmt.Println("    - ollama (本地)")
 		fmt.Println("    - google / google-vertex (Gemini)")
 		fmt.Println("    - Or any OpenAI-compatible provider (e.g., deepseek, moonshot, grok, chutes)")
@@ -273,6 +274,8 @@ func getDefaultBaseURL(provider string) string {
 		return "https://api.anthropic.com"
 	case "openrouter":
 		return "https://openrouter.ai/api/v1"
+	case "requesty":
+		return "https://router.requesty.ai/v1"
 	case "ollama":
 		return "http://localhost:11434/v1"
 	default:
@@ -290,6 +293,8 @@ func getDefaultModel(provider string) string {
 		return "claude-sonnet-4-20250514"
 	case "openrouter":
 		return "anthropic/claude-sonnet-4"
+	case "requesty":
+		return "anthropic/claude-sonnet-4-5"
 	case "ollama":
 		return "llama3.2"
 	default:

--- a/docs/PROJECT_SUMMARY.md
+++ b/docs/PROJECT_SUMMARY.md
@@ -27,7 +27,7 @@
 |------|----------|--------|------|
 | **技能系统** | ✅ | ✅ | 完全兼容 OpenClaw 技能格式 |
 | **工具系统** | ✅ | ✅ | FileSystem, Shell, Web, Browser |
-| **多 LLM 提供商** | ✅ | ✅ | OpenAI, Anthropic, OpenRouter |
+| **多 LLM 提供商** | ✅ | ✅ | OpenAI, Anthropic, OpenRouter, Requesty |
 | **OAuth 认证** | ✅ | ✅ | Anthropic, OpenAI OAuth 支持 |
 | **会话管理** | ✅ | ✅ | JSONL 格式，完整工具调用链 |
 | **消息通道** | ✅ | ✅ | 基础通道支持 |

--- a/docs/design/agent-design.md
+++ b/docs/design/agent-design.md
@@ -112,6 +112,7 @@ goclaw/
 │   ├── openai.go            # OpenAI
 │   ├── anthropic.go         # Anthropic
 │   ├── openrouter.go        # OpenRouter
+│   ├── requesty.go          # Requesty
 │   ├── rotation.go          # 轮换提供商
 │   ├── streaming.go         # 流式支持
 │   └── circuit.go           # 熔断器

--- a/docs/guide/config_guide.md
+++ b/docs/guide/config_guide.md
@@ -59,6 +59,12 @@ This guide covers configuring goclaw, including new features like multi-provider
       "base_url": "https://openrouter.ai/api/v1",
       "timeout": 60,
       "max_retries": 3
+    },
+    "requesty": {
+      "api_key": "sk-...",
+      "base_url": "https://router.requesty.ai/v1",
+      "timeout": 60,
+      "max_retries": 3
     }
   }
 }
@@ -276,6 +282,7 @@ Models can be specified with prefixes:
 - `qianfan:deepseek-v3.2`: Explicitly use Qianfan
 - `claude-3-opus-20240229`: Use Anthropic
 - `openrouter:anthropic/claude-opus-4-5`: Use OpenRouter
+- `requesty:anthropic/claude-sonnet-4-5`: Use Requesty
 - `openai:gpt-4-turbo`: Explicitly use OpenAI
 
 ## Tool Configuration

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -54,7 +54,7 @@ GoClaw 就是在这个背景下做出来的。
 
 Orchestrator 是核心协调器，它管理 LLM 调用、工具执行、状态维护。下面有 AgentState 管消息历史和队列，ContextBuilder 组装系统提示词，RetryManager 处理重试和故障转移。工具系统通过 ToolRegistry 注册，技能系统通过 SkillsLoader 加载。
 
-Provider 层负责对接 LLM。支持 OpenAI、Anthropic、OpenRouter 等提供商，还支持配置轮换和故障转移——主账号挂了自动切备用账号。
+Provider 层负责对接 LLM。支持 OpenAI、Anthropic、OpenRouter、Requesty 等提供商，还支持配置轮换和故障转移——主账号挂了自动切备用账号。
 
 ### 双循环机制：为什么很多 Agent 看起来能跑，其实一复杂就散？
 
@@ -424,7 +424,7 @@ AI Agent 一旦能读文件、跑命令、访问网络，安全就不是一个�
 
 ## LLM 提供商：别把整个系统的命门，交给一个模型或一个账号
 
-在工程实践里，模型能力当然重要，但更重要的是不要把整个系统绑死在单一模型或单一账号上。GoClaw 目前主要支持四类 provider：OpenAI、Qianfan（百度千帆，走 OpenAI-compatible 接口）、Anthropic，以及 OpenRouter。像 GPT-4、GPT-4o、DeepSeek 这类模型，只要底层接口兼容，也都可以接进来。
+在工程实践里，模型能力当然重要，但更重要的是不要把整个系统绑死在单一模型或单一账号上。GoClaw 目前主要支持五类 provider：OpenAI、Qianfan（百度千帆，走 OpenAI-compatible 接口）、Anthropic、OpenRouter，以及 Requesty（走 OpenAI-compatible 接口）。像 GPT-4、GPT-4o、DeepSeek 这类模型，只要底层接口兼容，也都可以接进来。
 
 因为一旦系统真的跑起来，限流、欠费、波动、服务异常都不是“小概率事件”，而是迟早会遇到的日常。
 
@@ -455,6 +455,12 @@ AI Agent 一旦能读文件、跑命令、访问网络，安全就不是一个�
     },
     "openrouter": {
       "api_key": "YOUR_OPENROUTER_API_KEY",
+      "base_url": "",
+      "timeout": 600,
+      "max_retries": 3
+    },
+    "requesty": {
+      "api_key": "YOUR_REQUESTY_API_KEY",
       "base_url": "",
       "timeout": 600,
       "max_retries": 3

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -177,6 +177,18 @@ GoClaw 支持多个 LLM 提供商：
 }
 ```
 
+**Requesty:**
+```json
+{
+  "providers": {
+    "requesty": {
+      "api_key": "sk-...",
+      "base_url": "https://router.requesty.ai/v1"
+    }
+  }
+}
+```
+
 #### 模型选择
 
 通过修改 `model` 参数选择不同的模型：
@@ -186,6 +198,7 @@ GoClaw 支持多个 LLM 提供商：
 - `openai:gpt-3.5-turbo` - OpenAI GPT-3.5
 - `claude-3-opus-20240229` - Anthropic Claude 3 Opus
 - `openrouter:anthropic/claude-opus-4-5` - 通过 OpenRouter 使用指定模型
+- `requesty:anthropic/claude-sonnet-4-5` - 通过 Requesty 使用指定模型
 
 ### 多账号配置
 

--- a/providers/requesty.go
+++ b/providers/requesty.go
@@ -1,0 +1,210 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/smallnest/goclaw/internal/logger"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/openai"
+	"go.uber.org/zap"
+)
+
+// RequestyProvider is the Requesty provider.
+type RequestyProvider struct {
+	llm       llms.Model
+	model     string
+	maxTokens int
+	timeout   time.Duration
+}
+
+// NewRequestyProvider creates a Requesty provider.
+func NewRequestyProvider(apiKey, baseURL, model string, maxTokens int) (*RequestyProvider, error) {
+	return NewRequestyProviderWithTimeout(apiKey, baseURL, model, maxTokens, 0)
+}
+
+// NewRequestyProviderWithTimeout creates a Requesty provider with a timeout.
+func NewRequestyProviderWithTimeout(apiKey, baseURL, model string, maxTokens int, timeout time.Duration) (*RequestyProvider, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+
+	if model == "" {
+		model = "anthropic/claude-sonnet-4-5"
+	}
+
+	if baseURL == "" {
+		baseURL = "https://router.requesty.ai/v1"
+	}
+
+	opts := []openai.Option{
+		openai.WithToken(apiKey),
+		openai.WithModel(model),
+		openai.WithBaseURL(baseURL),
+	}
+
+	// Configure timeout
+	if timeout > 0 {
+		httpClient := &http.Client{
+			Timeout: timeout,
+		}
+		opts = append(opts, openai.WithHTTPClient(httpClient))
+		logger.Info("Requesty provider configured with timeout",
+			zap.Duration("timeout", timeout))
+	}
+
+	llm, err := openai.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RequestyProvider{
+		llm:       llm,
+		model:     model,
+		maxTokens: maxTokens,
+		timeout:   timeout,
+	}, nil
+}
+
+// Chat performs a chat request.
+func (p *RequestyProvider) Chat(ctx context.Context, messages []Message, tools []ToolDefinition, options ...ChatOption) (*Response, error) {
+	opts := &ChatOptions{
+		Model:       p.model,
+		Temperature: 0.7,
+		MaxTokens:   p.maxTokens,
+		Stream:      false,
+	}
+
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	// Convert messages
+	langchainMessages := make([]llms.MessageContent, len(messages))
+	for i, msg := range messages {
+		var role llms.ChatMessageType
+		switch msg.Role {
+		case "user":
+			role = llms.ChatMessageTypeHuman
+		case "assistant":
+			role = llms.ChatMessageTypeAI
+		case "system":
+			role = llms.ChatMessageTypeSystem
+		case "tool":
+			role = llms.ChatMessageTypeTool
+		default:
+			role = llms.ChatMessageTypeHuman
+		}
+
+		// Handle tool result messages
+		if msg.Role == "tool" {
+			langchainMessages[i] = llms.MessageContent{
+				Role: role,
+				Parts: []llms.ContentPart{
+					llms.ToolCallResponse{
+						ToolCallID: msg.ToolCallID,
+						Name:       msg.ToolName,
+						Content:    msg.Content,
+					},
+				},
+			}
+		} else if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			// Handle assistant messages with tool calls
+			parts := []llms.ContentPart{
+				llms.TextPart(msg.Content),
+			}
+			for _, tc := range msg.ToolCalls {
+				args, _ := json.Marshal(tc.Params)
+				parts = append(parts, llms.ToolCall{
+					ID:   tc.ID,
+					Type: "function",
+					FunctionCall: &llms.FunctionCall{
+						Name:      tc.Name,
+						Arguments: string(args),
+					},
+				})
+			}
+			langchainMessages[i] = llms.MessageContent{
+				Role:  role,
+				Parts: parts,
+			}
+		} else {
+			langchainMessages[i] = llms.TextParts(role, msg.Content)
+		}
+	}
+
+	// Call the LLM
+	var llmOpts []llms.CallOption
+	if opts.Temperature > 0 {
+		llmOpts = append(llmOpts, llms.WithTemperature(float64(opts.Temperature)))
+	}
+	if opts.MaxTokens > 0 {
+		llmOpts = append(llmOpts, llms.WithMaxTokens(int(opts.MaxTokens)))
+	}
+
+	// If tools are present, add tool options
+	if len(tools) > 0 {
+		langchainTools := make([]llms.Tool, len(tools))
+		for i, tool := range tools {
+			langchainTools[i] = llms.Tool{
+				Type: "function",
+				Function: &llms.FunctionDefinition{
+					Name:        tool.Name,
+					Description: tool.Description,
+					Parameters:  tool.Parameters,
+				},
+			}
+		}
+		llmOpts = append(llmOpts, llms.WithTools(langchainTools))
+	}
+
+	completion, err := p.llm.GenerateContent(ctx, langchainMessages, llmOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate content: %w", err)
+	}
+
+	// Parse tool calls
+	var toolCalls []ToolCall
+	if len(completion.Choices) > 0 {
+		if len(completion.Choices[0].ToolCalls) > 0 {
+			logger.Debug("Found tool calls from LLM",
+				zap.Int("count", len(completion.Choices[0].ToolCalls)))
+		}
+		for _, tc := range completion.Choices[0].ToolCalls {
+			var params map[string]interface{}
+			if err := json.Unmarshal([]byte(tc.FunctionCall.Arguments), &params); err != nil {
+				logger.Error("Failed to unmarshal tool arguments",
+					zap.String("tool", tc.FunctionCall.Name),
+					zap.String("id", tc.ID),
+					zap.Error(err))
+				continue
+			}
+			toolCalls = append(toolCalls, ToolCall{
+				ID:     tc.ID,
+				Name:   tc.FunctionCall.Name,
+				Params: params,
+			})
+		}
+	}
+
+	response := &Response{
+		Content:      completion.Choices[0].Content,
+		ToolCalls:    toolCalls,
+		FinishReason: "stop",
+	}
+
+	return response, nil
+}
+
+// ChatWithTools performs a chat request with tools.
+func (p *RequestyProvider) ChatWithTools(ctx context.Context, messages []Message, tools []ToolDefinition, options ...ChatOption) (*Response, error) {
+	return p.Chat(ctx, messages, tools, options...)
+}
+
+// Close closes the connection.
+func (p *RequestyProvider) Close() error {
+	return nil
+}


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider, mirroring the existing OpenRouter provider.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router.

Changes:
- `providers/requesty.go`: new `RequestyProvider` mirroring `OpenRouterProvider` (langchaingo OpenAI client, default base URL `https://router.requesty.ai/v1`, default model `anthropic/claude-sonnet-4-5`).
- `cli/onboard.go`: default base URL/model, provider list, and `--provider` help.
- docs updated to list Requesty.

Model naming is `provider/model`. Verified: `go build ./...`, `go vet`, `go test ./providers/` pass, and a live `Chat` through `providers.NewRequestyProvider(...)` against the real endpoint returns a completion.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.